### PR TITLE
Fix docker build failure: `pip: command not found`

### DIFF
--- a/.project/spec.yaml
+++ b/.project/spec.yaml
@@ -21,7 +21,7 @@ layout:
 environment:
   base:
     registry: ghcr.io
-    image: huggingface/text-generation-inference:latest
+    image: huggingface/text-generation-inference:2.3.0
     build_timestamp: "20231011102429"
     name: TGI
     supported_architectures:


### PR DESCRIPTION
Your repo ~was forked off of~ last merged in NVIDIA's repo 7 months ago, and since then, the `latest` docker image has changed. Attempting to create a project in AI Workbench by cloning this repo resulted in the missing `pip` error in the title. This PR pins the base image to version to 2.3.0, the same change made upstream in https://github.com/NVIDIA/workbench-example-hybrid-rag/commit/758f60540d65296e0f36ee1eb30084634bf9345e.